### PR TITLE
Update ChatRoomActivity.java - HTTPS SNI fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,11 +7,20 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 21
-        versionCode 10
-        versionName "2.6.0"
+        versionCode 11
+        versionName "2.6.1"
     }
+    signingConfigs {
+       release {
+           storeFile file(OPENTOKRTC_RELEASE_STORE_FILE)
+           storePassword OPENTOKRTC_RELEASE_STORE_PASSWORD
+           keyAlias OPENTOKRTC_RELEASE_KEY_ALIAS
+           keyPassword OPENTOKRTC_RELEASE_KEY_PASSWORD
+       }
+   }
     buildTypes {
         release {
+            signingConfig signingConfigs.release
         }
     }
 
@@ -23,5 +32,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+   compile fileTree(dir: 'libs', include: '*.jar')
+   apk files('libs/opentok-android-sdk-2.0.jar')
 }


### PR DESCRIPTION
The endpoint OpenTokRTC-Android pulls room data from has been changed so that it explicitly requires SNI for a HTTPS connection, which the DefaultHttpClient class does not handle. This updates the class to HttpsURLConnection which does have SNI support and fixes the room JSON download.